### PR TITLE
fix(build): update release branch naming convention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
             Updated the version number from ${{steps.version_updater.outputs.old_version}} 
             to ${{needs.versioning.outputs.SemVer}} in the gradle.properties file to reflect 
             the latest release.
-          branch: actions/version-bump
+          branch: release/${{needs.versioning.outputs.SemVer}}
           title: 'Bump Version'
           body: >
             Updated the version number from ${{steps.version_updater.outputs.old_version}} 


### PR DESCRIPTION
Updated the GitHub Actions workflow to allow version bump and tagging for both push events and manual workflow dispatch. This change ensures that the version is bumped and tags are created when the workflow is triggered manually, improving flexibility in release management.
